### PR TITLE
Improve logging of packet decoding errors

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/BadPacketException.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/BadPacketException.java
@@ -1,6 +1,8 @@
 package net.md_5.bungee.protocol;
 
-public class BadPacketException extends RuntimeException
+import io.netty.handler.codec.DecoderException;
+
+public class BadPacketException extends DecoderException
 {
 
     public BadPacketException(String message)

--- a/protocol/src/main/java/net/md_5/bungee/protocol/DetailedBadPacketException.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DetailedBadPacketException.java
@@ -1,0 +1,63 @@
+package net.md_5.bungee.protocol;
+
+import io.netty.handler.codec.DecoderException;
+
+public class DetailedBadPacketException extends BadPacketException {
+
+    private final Integer packetId;
+    private final DefinedPacket packet;
+    private final Protocol protocol;
+    private final ProtocolConstants.Direction direction;
+
+    private static String makeMessage(String words, Integer packetId, DefinedPacket packet, Protocol protocol, ProtocolConstants.Direction direction) {
+        String msg = protocol.name() + ":" + direction.name() + " ";
+
+        if(packet != null) {
+            msg += packet.getClass().getSimpleName();
+        } else if(packetId != null) {
+            msg += "PACKET(" + Integer.toHexString(packetId) + ")";
+        }
+
+        if(words != null) {
+            msg = words + " [" + msg + "]";
+        }
+
+        return msg;
+    }
+
+    public DetailedBadPacketException(String message, Integer packetId, DefinedPacket packet, Protocol protocol, ProtocolConstants.Direction direction) {
+        this(message, null, packetId, packet, protocol, direction);
+    }
+
+    public DetailedBadPacketException(String message, Throwable cause, Integer packetId, DefinedPacket packet, Protocol protocol, ProtocolConstants.Direction direction) {
+        super(makeMessage(message, packetId, packet, protocol, direction),
+              (cause instanceof DecoderException && cause.getCause() != null) ? cause.getCause() : cause);
+
+        this.packetId = packetId;
+        this.packet = packet;
+        this.protocol = protocol;
+        this.direction = direction;
+    }
+
+    /**
+     * Return the ID of the packet that was bad, or null if no ID was decoded
+     */
+    public Integer getPacketId() {
+        return packetId;
+    }
+
+    /**
+     * Return the packet that failed to be read, or null if no known packet was ever instantiated
+     */
+    public DefinedPacket getPacket() {
+        return packet;
+    }
+
+    public Protocol getProtocol() {
+        return protocol;
+    }
+
+    public ProtocolConstants.Direction getDirection() {
+        return direction;
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -29,10 +29,17 @@ public class MinecraftDecoder extends ByteToMessageDecoder
         if ( prot.hasPacket( packetId ) )
         {
             packet = prot.createPacket( packetId );
-            packet.read( in, prot.getDirection(), protocolVersion );
+
+            try {
+                packet.read( in, prot.getDirection(), protocolVersion );
+            }
+            catch(Exception e) {
+                throw new DetailedBadPacketException("Exception decoding packet", e, packetId, packet, protocol, prot.getDirection());
+            }
+
             if ( in.readableBytes() != 0 )
             {
-                throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot );
+                throw new DetailedBadPacketException(in.readableBytes() + " bytes remain after decoding packet", packetId, packet, protocol, prot.getDirection());
             }
         } else
         {

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.netty;
 
+import net.md_5.bungee.protocol.DetailedBadPacketException;
 import net.md_5.bungee.protocol.PacketWrapper;
 import com.google.common.base.Preconditions;
 import io.netty.channel.ChannelHandlerContext;
@@ -12,6 +13,7 @@ import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.protocol.BadPacketException;
+import net.md_5.bungee.protocol.packet.Handshake;
 
 /**
  * This class is a primitive wrapper for {@link PacketHandler} instances tied to
@@ -97,9 +99,12 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
             if ( cause instanceof ReadTimeoutException )
             {
                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - read timed out", handler );
+            } else if ( cause instanceof DetailedBadPacketException && ((DetailedBadPacketException) cause).getPacket() instanceof Handshake)
+            {
+                ProxyServer.getInstance().getLogger().log( Level.WARNING, handler + " - bad handshake packet: " + cause.getMessage() );
             } else if ( cause instanceof BadPacketException )
             {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet ID, are mods in use!?", handler );
+                ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - " + cause, cause );
             } else if ( cause instanceof IOException )
             {
                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - IOException: {1}", new Object[]


### PR DESCRIPTION
- Inherit `BadPacketException` from `DecoderException` to prevent it from getting wrapped in the latter in some cases
- Add `DetailedBadPacketException` and use it to wrap anything thrown while decoding a packet
- Log packet decoding errors at SEVERE level, _if_ they are not the `Handshake` packet i.e. the first packet read. Hopefully, this will seperate the important stuff from the noise.
